### PR TITLE
Change professional compiler erroring to #error

### DIFF
--- a/hardware_functions.cpp
+++ b/hardware_functions.cpp
@@ -52,7 +52,6 @@ QString get_hdid()
 
 #else
 
-//throwing compile-time errors professionally
-fhasdfuifhidfhasjkfasdkfahsdj
+#error This operating system is unsupported for hardware functions.
 
 #endif


### PR DESCRIPTION
So professional. `#error` is the correct directive here and is supported by the major compilers.