### PR TITLE
Unicode support for BASS

### DIFF
--- a/aoblipplayer.cpp
+++ b/aoblipplayer.cpp
@@ -18,7 +18,7 @@ void AOBlipPlayer::set_blips(QString p_sfx)
   {
     BASS_StreamFree(m_stream_list[n_stream]);
 
-    m_stream_list[n_stream] = BASS_StreamCreateFile(FALSE, f_path.toStdString().c_str(), 0, 0, 0);
+    m_stream_list[n_stream] = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_UNICODE | BASS_ASYNCFILE);
   }
 
   set_volume(m_volume);

--- a/aomusicplayer.cpp
+++ b/aomusicplayer.cpp
@@ -21,7 +21,7 @@ void AOMusicPlayer::play(QString p_song)
 
   QString f_path = ao_app->get_music_path(p_song);
 
-  m_stream = BASS_StreamCreateFile(FALSE, f_path.toStdString().c_str(), 0, 0, BASS_STREAM_AUTOFREE);
+  m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
 
   this->set_volume(m_volume);
 

--- a/aosfxplayer.cpp
+++ b/aosfxplayer.cpp
@@ -23,7 +23,7 @@ void AOSfxPlayer::play(QString p_sfx, QString p_char)
   else
     f_path = ao_app->get_sounds_path() + p_sfx;
 
-  m_stream = BASS_StreamCreateFile(FALSE, f_path.toStdString().c_str(), 0, 0, BASS_STREAM_AUTOFREE);
+  m_stream = BASS_StreamCreateFile(FALSE, f_path.utf16(), 0, 0, BASS_STREAM_AUTOFREE | BASS_UNICODE | BASS_ASYNCFILE);
 
   set_volume(m_volume);
 


### PR DESCRIPTION
This fixes the issue where a path containing a Unicode character, such as an accent mark, would prevent sounds from being played.

The issue was reproducible, and this fix was tested to work.